### PR TITLE
add ?~> and ?:= combinators

### DIFF
--- a/src/Data/Argonaut.purs
+++ b/src/Data/Argonaut.purs
@@ -1,7 +1,9 @@
 module Data.Argonaut
   -- Combinators
   ( (:=)
+  , (?:=)
   , (~>)
+  , (?~>)
   , (?>>=)
   , (.?)
   -- Core
@@ -83,12 +85,16 @@ module Data.Argonaut
   -- | Combinators
 
   infix  7 :=
+  infix  7 ?:=
   infix  7 .?
   infixr 6 ~>
+  infixr 6 ?~>
   infixl 1 ?>>=
 
   (:=)   = Combinators.(:=)
+  (?:=)  = Combinators.(?:=)
   (~>)   = Combinators.(~>)
+  (?~>)  = Combinators.(?~>)
   (?>>=) = Combinators.(?>>=)
   (.?)   = Combinators.(.?)
 
@@ -113,7 +119,7 @@ module Data.Argonaut
   downField   = JCursor.downField
   downIndex   = JCursor.downIndex
   insideOut   = JCursor.insideOut
-  toPrims     = JCursor.toPrims  
+  toPrims     = JCursor.toPrims
 
   -- Prims
   primNull    = JCursor.primNull

--- a/src/Data/Argonaut/Combinators.purs
+++ b/src/Data/Argonaut/Combinators.purs
@@ -1,6 +1,8 @@
 module Data.Argonaut.Combinators
   ( (:=)
+  , (?:=)
   , (~>)
+  , (?~>)
   , (?>>=)
   , (.?)
   ) where
@@ -28,6 +30,13 @@ module Data.Argonaut.Combinators
 
   (:=) :: forall a. (EncodeJson a) => String -> a -> JAssoc
   (:=) k v = Tuple k $ encodeJson v
+
+  (?:=) :: forall a. (EncodeJson a) => String -> Maybe a -> Maybe JAssoc
+  (?:=) k v = ((:=) k) <<< encodeJson <$> v
+
+  (?~>) :: forall a. (EncodeJson a) => Maybe JAssoc -> a -> Json
+  (?~>) (Just kv) x = kv ~> x
+  (?~>) Nothing   x = encodeJson x
 
   (~>) :: forall a. (EncodeJson a) => JAssoc -> a -> Json
   (~>) (Tuple k v) a = foldJsonObject (jsonSingletonObject k v) (M.insert k v >>> fromObject) (encodeJson a)

--- a/src/Data/Argonaut/README.md
+++ b/src/Data/Argonaut/README.md
@@ -12,7 +12,13 @@
     (:=) :: forall a. (EncodeJson a) => String -> a -> JAssoc
 
 
+    (?:=) :: forall a. (EncodeJson a) => String -> Maybe a -> Maybe JAssoc
+
+
     (?>>=) :: forall a b. Maybe a -> String -> Either String a
+
+
+    (?~>) :: forall a. (EncodeJson a) => Maybe JAssoc -> a -> Json
 
 
     (~>) :: forall a. (EncodeJson a) => JAssoc -> a -> Json


### PR DESCRIPTION
Example usage

``` haskell
instance encodeJsonOption :: EncodeJson Option where
  encodeJson (Option o)
    =   "backgroundColor" ?:= o.backgroundColor
    ?~> "color"           ?:= o.color
    ?~> jsonEmptyObject
```

If `backgroundColor` is `Nothing`, it results into

``` json
{
  "color": "#ff0000"
}
```
