### PR TITLE
Add link to purescript-argonaut-core/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Build Status](https://travis-ci.org/purescript-contrib/purescript-argonaut.svg)](https://travis-ci.org/purescript-contrib/purescript-argonaut)
 [![Maintainer: slamdata](https://img.shields.io/badge/maintainer-slamdata-lightgrey.svg)](http://github.com/slamdata)
 
+Go to [purescript-argonaut-core/README.md](https://github.com/purescript-contrib/purescript-argonaut-core/blob/master/README.md) to read an overview of Argonaut and how to use it.
+
 This library bundles together the following:
 
 - [purescript-argonaut-core](https://github.com/purescript-contrib/purescript-argonaut-core) - basic parsing, printing, folding and types for `Json`


### PR DESCRIPTION
I overlooked the docs for this project until I was pointed to the purescript-argonaut-core's README, which is quite great. We should like to it from the other repos in this project.