### PR TITLE
Update for PureScript 0.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,12 +11,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "purescript-argonaut-codecs": "^2.0.0",
-    "purescript-argonaut-core": "^2.0.0",
-    "purescript-argonaut-traversals": "^2.0.0"
+    "purescript-argonaut-codecs": "^3.0.0",
+    "purescript-argonaut-core": "^3.0.0",
+    "purescript-argonaut-traversals": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^2.0.0",
-    "purescript-strongcheck": "^2.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-strongcheck": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "test": "pulp build --include examples --censor-lib --strict && pulp test"
   },
   "devDependencies": {
-    "pulp": "^9.0.1",
-    "purescript-psa": "^0.3.9",
-    "purescript": "^0.10.1",
+    "pulp": "^11.0.0",
+    "purescript-psa": "^0.5.0",
+    "purescript": "^0.11.0",
     "rimraf": "^2.5.4"
   }
 }

--- a/src/Data/Argonaut.purs
+++ b/src/Data/Argonaut.purs
@@ -4,16 +4,14 @@ module Data.Argonaut
   , module Data.Argonaut.Encode
   , module Data.Argonaut.JCursor
   , module Data.Argonaut.Parser
-  , module Data.Argonaut.Printer
   , module Data.Argonaut.Prisms
   , module Data.Argonaut.Traversals
   ) where
 
 import Data.Argonaut.Core (JArray, JAssoc, JBoolean, JNull, JNumber, JObject, JString, Json, foldJson, foldJsonArray, foldJsonBoolean, foldJsonNull, foldJsonNumber, foldJsonObject, foldJsonString, fromArray, fromBoolean, fromNull, fromNumber, fromObject, fromString, isArray, isBoolean, isNull, isNumber, isObject, isString, jsonEmptyArray, jsonEmptyObject, jsonFalse, jsonNull, jsonSingletonArray, jsonSingletonObject, jsonTrue, jsonZero, toArray, toBoolean, toNull, toNumber, toObject, toString)
-import Data.Argonaut.Decode (class DecodeJson, decodeJson, gDecodeJson, gDecodeJson', getField, (.?))
-import Data.Argonaut.Encode (class EncodeJson, assoc, encodeJson, extend, gEncodeJson, gEncodeJson', (:=), (~>))
+import Data.Argonaut.Decode (class DecodeJson, decodeJson, getField, (.?))
+import Data.Argonaut.Encode (class EncodeJson, assoc, encodeJson, extend, (:=), (~>))
 import Data.Argonaut.JCursor (JCursor(..), JsonPrim(..), cursorGet, cursorSet, downField, downIndex, exactNull, fail, fromPrims, inferEmpty, insideOut, primBool, primNull, primNum, primStr, primToJson, runJsonPrim, toPrims)
 import Data.Argonaut.Parser (jsonParser)
-import Data.Argonaut.Printer (class Printer, printJson)
 import Data.Argonaut.Prisms (_Array, _Boolean, _Null, _Number, _Object, _String)
 import Data.Argonaut.Traversals (_JsonArray, _JsonBoolean, _JsonNull, _JsonNumber, _JsonObject, _JsonString)


### PR DESCRIPTION
This shouldn't pass CI checks yet because `purescript-argonaut-traverals` 3.0.0 doesn't exist, but it should soon! Everything else should be fine though.