### PR TITLE
Re-export Data.Argonaut.Core.stringifyWithIndent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Bugfixes:
 
 Other improvements:
 
+- Re-exported `Data.Argonaut.Core.stringifyWithIndent`.
+
 ## [v7.0.0](https://github.com/purescript-contrib/purescript-argonaut/releases/tag/v7.0.0) - 2020-06-20
 
 Updates dependencies to account for the [typed errors introduced in `argonaut-codecs` v7.0.0](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v7.0.0). These types produce richer information to understand errors that have occurred, which can also be printed as human-readable errors.

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "purescript-argonaut-codecs": "^7.0.0",
-    "purescript-argonaut-core": "^5.0.0",
+    "purescript-argonaut-core": "^5.1.0",
     "purescript-argonaut-traversals": "^8.0.0"
   },
   "devDependencies": {

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200831/packages.dhall sha256:cdb3529cac2cd8dd780f07c80fd907d5faceae7decfcaa11a12037df68812c83
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20201125/packages.dhall sha256:ef58d9afae22d1bc9d83db8c72d0a4eca30ce052ab49bbc44ced2da0bc5cad1a
 
 in  upstream

--- a/src/Data/Argonaut.purs
+++ b/src/Data/Argonaut.purs
@@ -9,7 +9,7 @@ module Data.Argonaut
   ) where
 
 
-import Data.Argonaut.Core (Json, caseJson, caseJsonArray, caseJsonBoolean, caseJsonNull, caseJsonNumber, caseJsonObject, caseJsonString, fromArray, fromBoolean, fromNumber, fromObject, fromString, isArray, isBoolean, isNull, isNumber, isObject, isString, jsonEmptyArray, jsonEmptyObject, jsonEmptyString, jsonFalse, jsonNull, jsonSingletonArray, jsonSingletonObject, jsonTrue, jsonZero, stringify, toArray, toBoolean, toNull, toNumber, toObject, toString)
+import Data.Argonaut.Core (Json, caseJson, caseJsonArray, caseJsonBoolean, caseJsonNull, caseJsonNumber, caseJsonObject, caseJsonString, fromArray, fromBoolean, fromNumber, fromObject, fromString, isArray, isBoolean, isNull, isNumber, isObject, isString, jsonEmptyArray, jsonEmptyObject, jsonEmptyString, jsonFalse, jsonNull, jsonSingletonArray, jsonSingletonObject, jsonTrue, jsonZero, stringify, stringifyWithIndent, toArray, toBoolean, toNull, toNumber, toObject, toString)
 import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError(..), decodeJson, defaultField, getField, getFieldOptional, getFieldOptional', parseJson, printJsonDecodeError, (.!=), (.:), (.:!), (.:?))
 import Data.Argonaut.Encode (class EncodeJson, assoc, assocOptional, encodeJson, extend, extendOptional, (:=), (:=?), (~>), (~>?))
 import Data.Argonaut.JCursor (JCursor(..), JsonPrim(..), cursorGet, cursorSet, downField, downIndex, fromPrims, inferEmpty, insideOut, primBool, primNull, primNum, primStr, primToJson, print, runJsonPrim, toPrims)


### PR DESCRIPTION
**Description of the change**
`Data.Argonaut.Core.stringifyWithIndent` was added in https://github.com/purescript-contrib/purescript-argonaut-core/pull/41 but unlike `Data.Argonaut.Core.stringify` it isn’t re-exported from `Data.Argonaut`, I assume this was an oversight.