### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#6 by @thomashoneyman)
 
 ## [v8.0.0](https://github.com/purescript-contrib/purescript-argonaut/releases/tag/v8.0.0) - 2021-02-26
 

--- a/src/Data/Argonaut.purs
+++ b/src/Data/Argonaut.purs
@@ -8,7 +8,6 @@ module Data.Argonaut
   , module Data.Argonaut.Traversals
   ) where
 
-
 import Data.Argonaut.Core (Json, caseJson, caseJsonArray, caseJsonBoolean, caseJsonNull, caseJsonNumber, caseJsonObject, caseJsonString, fromArray, fromBoolean, fromNumber, fromObject, fromString, isArray, isBoolean, isNull, isNumber, isObject, isString, jsonEmptyArray, jsonEmptyObject, jsonEmptyString, jsonFalse, jsonNull, jsonSingletonArray, jsonSingletonObject, jsonTrue, jsonZero, stringify, stringifyWithIndent, toArray, toBoolean, toNull, toNumber, toObject, toString)
 import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError(..), decodeJson, defaultField, getField, getFieldOptional, getFieldOptional', parseJson, printJsonDecodeError, (.!=), (.:), (.:!), (.:?))
 import Data.Argonaut.Encode (class EncodeJson, assoc, assocOptional, encodeJson, extend, extendOptional, (:=), (:=?), (~>), (~>?))

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -24,11 +24,12 @@ prop_toPrims_fromPrims = do
 
 genTestJCursor :: Gen JCursor
 genTestJCursor = do
-    i <- chooseInt 0 2
-    r <- if i == 0 then pure JCursorTop
-         else if i == 1 then JField <$> genUnicodeString <*> genTestJCursor
-              else JIndex <$> chooseInt bottom top <*> genTestJCursor
-    pure r
+  i <- chooseInt 0 2
+  r <-
+    if i == 0 then pure JCursorTop
+    else if i == 1 then JField <$> genUnicodeString <*> genTestJCursor
+    else JIndex <$> chooseInt bottom top <*> genTestJCursor
+  pure r
 
 prop_jcursor_serialization :: Gen Result
 prop_jcursor_serialization = do


### PR DESCRIPTION
**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
